### PR TITLE
feat(config): update config server URL to use port 8888

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,6 @@ spring:
   application:
     name: api-gateway
   config:
-    import: configserver:http://localhost:8000
+    import: configserver:http://localhost:8888
   profiles:
     active: dev


### PR DESCRIPTION
This pull request updates the configuration for the `api-gateway` application to use a different config server port.

- Configuration update:
  * Changed the `configserver` port in `src/main/resources/application.yml` from `8000` to `8888` to point to the correct configuration server.